### PR TITLE
Fix panic when table does not exist

### DIFF
--- a/book.go
+++ b/book.go
@@ -30,29 +30,29 @@ func allBooks() ([]Book, error) {
 	books := []Book{}
 
 	rows, err := db.Query(`SELECT id, name, author, pages, publication_date FROM books order by id`)
+	if err != nil {
+		return nil, err
+	}
 	defer rows.Close()
-	if err == nil {
-		for rows.Next() {
-			var id int
-			var name string
-			var author string
-			var pages int
-			var publicationDate pq.NullTime
 
-			err = rows.Scan(&id, &name, &author, &pages, &publicationDate)
-			if err == nil {
-				currentBook := Book{ID: id, Name: name, Author: author, Pages: pages}
-				if publicationDate.Valid {
-					currentBook.PublicationDate = publicationDate.Time
-				}
+	for rows.Next() {
+		var id int
+		var name string
+		var author string
+		var pages int
+		var publicationDate pq.NullTime
 
-				books = append(books, currentBook)
-			} else {
-				return books, err
-			}
+		err = rows.Scan(&id, &name, &author, &pages, &publicationDate)
+		if err != nil {
+			return books, err
 		}
-	} else {
-		return books, err
+
+		currentBook := Book{ID: id, Name: name, Author: author, Pages: pages}
+		if publicationDate.Valid {
+			currentBook.PublicationDate = publicationDate.Time
+		}
+
+		books = append(books, currentBook)
 	}
 
 	return books, err


### PR DESCRIPTION
Before:

```
2020/03/17 22:10:01 http: panic serving [::1]:57329: runtime error: invalid memory address or nil pointer dereference
goroutine 53 [running]:
net/http.(*conn).serve.func1(0xc000226320)
	/usr/local/go/src/net/http/server.go:1772 +0x139
panic(0x13a6d80, 0x1720ac0)
	/usr/local/go/src/runtime/panic.go:973 +0x396
database/sql.(*Rows).close(0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/database/sql/sql.go:3063 +0x76
database/sql.(*Rows).Close(0x0, 0x14a3020, 0xc0000be008)
	/usr/local/go/src/database/sql/sql.go:3059 +0x33
main.allBooks(0x1757f08, 0x0, 0x0, 0x149b9a0, 0xc00023c120)
	/Users/prashanthpai/go/src/github.com/filewalkwithme/go-pg-crud/book.go:55 +0x5d5
main.handleListBooks(0x14a2460, 0xc00025e0e0, 0xc000254100)
	/Users/prashanthpai/go/src/github.com/filewalkwithme/go-pg-crud/http-handlers.go:68 +0x34
net/http.HandlerFunc.ServeHTTP(0x142b388, 0x14a2460, 0xc00025e0e0, 0xc000254100)
	/usr/local/go/src/net/http/server.go:2012 +0x44
net/http.(*ServeMux).ServeHTTP(0x172d460, 0x14a2460, 0xc00025e0e0, 0xc000254100)
	/usr/local/go/src/net/http/server.go:2387 +0x1a5
net/http.serverHandler.ServeHTTP(0xc00010a000, 0x14a2460, 0xc00025e0e0, 0xc000254100)
	/usr/local/go/src/net/http/server.go:2807 +0xa3
net/http.(*conn).serve(0xc000226320, 0x14a2fe0, 0xc000214140)
	/usr/local/go/src/net/http/server.go:1895 +0x86c
created by net/http.(*Server).Serve
	/usr/local/go/src/net/http/server.go:2933 +0x35c
```

After:

![Screenshot 2020-03-17 at 10 11 44 PM](https://user-images.githubusercontent.com/44771475/76879553-6a8c7c00-689c-11ea-82b2-5605833b832c.png)
